### PR TITLE
Update glusterd.te

### DIFF
--- a/glusterd.if
+++ b/glusterd.if
@@ -301,6 +301,15 @@ interface(`glusterd_admin',`
 ')
 
 ########################################
+# 
+# Interface compatibility blocks
+#
+# The following definitions ensure compatibility with distribution policy
+# versions that do not contain given interfaces.
+# Each block tests for existence of given interface and defines it if needed.
+#
+
+########################################
 ## <summary>
 ##	Read and write rsync unix_stream_sockets.
 ## </summary>

--- a/glusterd.if
+++ b/glusterd.if
@@ -299,3 +299,23 @@ interface(`glusterd_admin',`
 	admin_pattern($1, glusterd_conf_t)
 
 ')
+
+########################################
+## <summary>
+##	Read and write rsync unix_stream_sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`rsync_rw_unix_stream_sockets',`
+	interface(`rsync_rw_unix_stream_sockets',`
+        	gen_require(`
+	    		type rsync_t;
+		')
+
+		allow $1 rsync_t:unix_stream_socket rw_socket_perms;
+	')
+')

--- a/glusterd.te
+++ b/glusterd.te
@@ -309,6 +309,7 @@ optional_policy(`
 
 optional_policy(`
 	rsync_exec(glusterd_t)
+	rsync_rw_unix_stream_sockets(glusterd_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
The entry is required for allowing gluster geo-replication in rsync-mode.
For reference, I've referred to the patch made to fedora-selinux/selinux-policy-contrib : https://github.com/fedora-selinux/selinux-policy-contrib/pull/242/commits/6fab75f5c3c6737cebe97f151d29aaa2ee68427a