### PR TITLE
Fix policy style

### DIFF
--- a/glusterd.fc
+++ b/glusterd.fc
@@ -6,13 +6,12 @@
 /usr/sbin/glusterd	--	gen_context(system_u:object_r:glusterd_initrc_exec_t,s0)
 /usr/sbin/glusterfsd	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
 
-/usr/sbin/glustereventsd   -- 	gen_context(system_u:object_r:glusterd_exec_t,s0)
-/usr/sbin/gluster-eventsapi   -- 	gen_context(system_u:object_r:glusterd_exec_t,s0)
+/usr/sbin/glustereventsd	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
+/usr/sbin/gluster-eventsapi	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
 
-
-/usr/libexec/glusterfs/peer_eventsapi.py    -- 	gen_context(system_u:object_r:glusterd_exec_t,s0)
-/usr/libexec/glusterfs/events/glustereventsd.py   -- 	gen_context(system_u:object_r:glusterd_exec_t,s0)
-/usr/libexec/glusterfs/gfevents/glustereventsd.py   -- 	gen_context(system_u:object_r:glusterd_exec_t,s0)
+/usr/libexec/glusterfs/peer_eventsapi\.py		--	gen_context(system_u:object_r:glusterd_exec_t,s0)
+/usr/libexec/glusterfs/events/glustereventsd\.py	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
+/usr/libexec/glusterfs/gfevents/glustereventsd\.py	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
 
 /opt/glusterfs/[^/]+/sbin/glusterfsd	--	gen_context(system_u:object_r:glusterd_exec_t,s0)
 
@@ -20,7 +19,7 @@
 
 /var/log/glusterfs(/.*)?	gen_context(system_u:object_r:glusterd_log_t,s0)
 
-/var/run/gluster(/.*)?	gen_context(system_u:object_r:glusterd_var_run_t,s0)
-/var/run/glusterd(/.*)?	gen_context(system_u:object_r:glusterd_var_run_t,s0)
+/var/run/gluster(/.*)?		gen_context(system_u:object_r:glusterd_var_run_t,s0)
+/var/run/glusterd(/.*)?		gen_context(system_u:object_r:glusterd_var_run_t,s0)
 /var/run/glusterd.*	--	gen_context(system_u:object_r:glusterd_var_run_t,s0)
 /var/run/glusterd.*	-s	gen_context(system_u:object_r:glusterd_var_run_t,s0)

--- a/glusterd.if
+++ b/glusterd.if
@@ -90,10 +90,10 @@ interface(`glusterd_append_log',`
 ## </param>
 #
 interface(`glusterd_filetrans_named_pid',`
-    gen_require(`
-        type glusterd_var_run_t;
-    ')
-    files_pid_filetrans($1, glusterd_var_run_t , sock_file, "glusterd.socket")
+	gen_require(`
+		type glusterd_var_run_t;
+	')
+	files_pid_filetrans($1, glusterd_var_run_t , sock_file, "glusterd.socket")
 ')
 
 ########################################
@@ -139,118 +139,118 @@ interface(`glusterd_manage_log',`
 
 ######################################
 ## <summary>
-##  Allow the specified domain to execute gluster's lib files.
+##	Allow the specified domain to execute gluster's lib files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`gluster_execute_lib',`
-    gen_require(`
-        type glusterd_var_lib_t;
-    ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    files_list_var_lib($1)
-    allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    can_exec($1, glusterd_var_lib_t)
+	files_list_var_lib($1)
+	allow $1 glusterd_var_lib_t:dir search_dir_perms;
+	can_exec($1, glusterd_var_lib_t)
 ')
 
 ######################################
 ## <summary>
-##  Read glusterd's config files.
+##	Read glusterd's config files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_read_conf',`
-       gen_require(`
-               type glusterd_conf_t;
-       ')
+	gen_require(`
+	type glusterd_conf_t;
+	')
 
-    files_search_etc($1)
-    read_files_pattern($1, glusterd_conf_t, glusterd_conf_t)
+	files_search_etc($1)
+	read_files_pattern($1, glusterd_conf_t, glusterd_conf_t)
 ')
 
 ######################################
 ## <summary>
-##  Dontaudit Read  /var/lib/glusterd files.
+##	Dontaudit Read  /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_dontaudit_read_lib_dirs',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    dontaudit $1 glusterd_var_lib_t:dir list_dir_perms;
+	dontaudit $1 glusterd_var_lib_t:dir list_dir_perms;
 ')
 
 ######################################
 ## <summary>
-##  Read and write /var/lib/glusterd files.
+##	Read and write /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_rw_lib',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+	type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
-    rw_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	files_search_var_lib($1)
+	rw_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
 ## <summary>
-## Read /var/lib/glusterd files.
+##	Read /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_read_lib_files',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+	type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
+	files_search_var_lib($1)
 	allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    read_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	read_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
 ## <summary>
-## Read and write /var/lib/glusterd files.
+##	Read and write /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_manage_lib_files',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+	type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
+	files_search_var_lib($1)
 	allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    manage_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	manage_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
@@ -282,9 +282,9 @@ interface(`glusterd_admin',`
 	allow $1 glusterd_t:process { signal_perms };
 	ps_process_pattern($1, glusterd_t)
 
-    tunable_policy(`deny_ptrace',`',`
-        allow $1 glusterd_t:process ptrace;
-    ')
+	tunable_policy(`deny_ptrace',`',`
+		allow $1 glusterd_t:process ptrace;
+	')
 
 	glusterd_initrc_domtrans($1)
 	domain_system_change_exemption($1)
@@ -321,8 +321,8 @@ interface(`glusterd_admin',`
 #
 ifndef(`rsync_rw_unix_stream_sockets',`
 	interface(`rsync_rw_unix_stream_sockets',`
-        	gen_require(`
-	    		type rsync_t;
+		gen_require(`
+			type rsync_t;
 		')
 
 		allow $1 rsync_t:unix_stream_socket rw_socket_perms;

--- a/glusterd.te
+++ b/glusterd.te
@@ -69,14 +69,14 @@ files_type(glusterd_brick_t)
 # Local policy
 #
 
-allow glusterd_t self:capability { sys_admin sys_resource sys_ptrace chown dac_read_search dac_override fowner fsetid ipc_lock kill setgid setuid net_admin mknod net_raw };
+allow glusterd_t self:capability { chown dac_override dac_read_search fowner fsetid ipc_lock kill mknod net_admin net_raw setgid setuid sys_admin sys_ptrace sys_resource };
 
 allow glusterd_t self:capability2 block_suspend;
-allow glusterd_t self:process { getcap setcap setpgid setrlimit signal_perms setsched getsched setfscreate};
+allow glusterd_t self:process { getcap getsched setcap setfscreate setpgid setrlimit setsched signal_perms };
 allow glusterd_t self:sem create_sem_perms;
 allow glusterd_t self:fifo_file rw_fifo_file_perms;
 allow glusterd_t self:tcp_socket { accept listen };
-allow glusterd_t self:unix_stream_socket { accept listen connectto };
+allow glusterd_t self:unix_stream_socket { accept connectto listen };
 allow glusterd_t self:rawip_socket create_socket_perms;
 allow glusterd_t self:unix_stream_socket create_stream_socket_perms;
 allow glusterd_t self:netlink_rdma_socket create_socket_perms;
@@ -197,8 +197,6 @@ storage_raw_write_fixed_disk(glusterd_t)
 
 auth_use_nsswitch(glusterd_t)
 
-fs_getattr_all_fs(glusterd_t)
-
 init_domtrans_script(glusterd_t)
 init_initrc_domain(glusterd_t)
 init_read_script_state(glusterd_t)
@@ -206,9 +204,6 @@ init_rw_script_tmp_files(glusterd_t)
 init_manage_script_status_files(glusterd_t)
 init_status(glusterd_t)
 init_stop_transient_unit(glusterd_t)
-
-systemd_config_systemd_services(glusterd_t)
-systemd_signal_passwd_agent(glusterd_t)
 
 logging_send_syslog_msg(glusterd_t)
 logging_dontaudit_search_audit_logs(glusterd_t)
@@ -227,10 +222,6 @@ userdom_map_tmp_files(glusterd_t)
 userdom_kill_all_users(glusterd_t)
 userdom_signal_unpriv_users(glusterd_t)
 
-mount_domtrans(glusterd_t)
-
-fstools_domtrans(glusterd_t)
-
 tunable_policy(`gluster_anon_write',`
 	miscfiles_manage_public_files(glusterd_t)
 ') 
@@ -238,18 +229,18 @@ tunable_policy(`gluster_anon_write',`
 tunable_policy(`gluster_export_all_ro',`
 	fs_read_noxattr_fs_files(glusterd_t) 
 	files_read_non_security_files(glusterd_t) 
-    files_getattr_all_pipes(glusterd_t)
-    files_getattr_all_sockets(glusterd_t)
+	files_getattr_all_pipes(glusterd_t)
+	files_getattr_all_sockets(glusterd_t)
 ')
 
 tunable_policy(`gluster_export_all_rw',`
 	fs_manage_noxattr_fs_files(glusterd_t) 
 	files_manage_non_security_dirs(glusterd_t)
 	files_manage_non_security_files(glusterd_t)
-    files_relabel_base_file_types(glusterd_t)
-    files_getattr_all_pipes(glusterd_t)
-    files_getattr_all_sockets(glusterd_t)
-    files_map_non_security_files(glusterd_t)
+	files_relabel_base_file_types(glusterd_t)
+	files_getattr_all_pipes(glusterd_t)
+	files_getattr_all_sockets(glusterd_t)
+	files_map_non_security_files(glusterd_t)
 ')
 
 tunable_policy(`gluster_use_execmem',`
@@ -257,55 +248,80 @@ tunable_policy(`gluster_use_execmem',`
 ')
 
 optional_policy(`
-    automount_write_pipes(glusterd_t)
+	automount_write_pipes(glusterd_t)
 ')
 
 optional_policy(`
-    ctdbd_domtrans(glusterd_t)
-    ctdbd_signal(glusterd_t)
+	ctdbd_domtrans(glusterd_t)
+	ctdbd_signal(glusterd_t)
 ')
 
 optional_policy(`
-    dbus_system_bus_client(glusterd_t)
-    dbus_connect_system_bus(glusterd_t)
+	dbus_system_bus_client(glusterd_t)
+	dbus_connect_system_bus(glusterd_t)
 	unconfined_dbus_chat(glusterd_t)
 
-    optional_policy(`
-        policykit_dbus_chat(glusterd_t)
-    ')
+	optional_policy(`
+		policykit_dbus_chat(glusterd_t)
+	')
 ')
 
 optional_policy(`
-    hostname_exec(glusterd_t)
+	fstools_domtrans(glusterd_t)
+')
+
+optional_policy(`
+	hostname_exec(glusterd_t)
 ')
 
 
 optional_policy(`
-    kerberos_read_keytab(glusterd_t)
+	kerberos_read_keytab(glusterd_t)
 ')
 
 optional_policy(`
-    lvm_domtrans(glusterd_t)
+	lvm_domtrans(glusterd_t)
 ')
 
 optional_policy(`
-    mount_domtrans_showmount(glusterd_t)
+	mount_domtrans(glusterd_t)
+	mount_domtrans_showmount(glusterd_t)
 ')
 
 optional_policy(`
-    samba_domtrans_smbd(glusterd_t)
-    samba_systemctl(glusterd_t)
-    samba_signal_smbd(glusterd_t)
-    samba_manage_config(glusterd_t)
+	samba_domtrans_smbd(glusterd_t)
+	samba_systemctl(glusterd_t)
+	samba_signal_smbd(glusterd_t)
+	samba_manage_config(glusterd_t)
 ')
 
 optional_policy(`
-    ssh_exec_keygen(glusterd_t)
+	ssh_exec(glusterd_t)
+	ssh_exec_keygen(glusterd_t)
 ')
 
 optional_policy(`
-    rpc_domtrans_rpcd(glusterd_t)
-    rpc_kill_rpcd(glusterd_t)
+	systemd_config_systemd_services(glusterd_t)
+	systemd_signal_passwd_agent(glusterd_t)
+')
+
+optional_policy(`
+        rhcs_dbus_chat_cluster(glusterd_t)
+        rhcs_domtrans_cluster(glusterd_t)
+        rhcs_systemctl_cluster(glusterd_t)
+        rhcs_stream_connect_cluster(glusterd_t)
+')
+
+optional_policy(`
+	rpc_dbus_chat_nfsd(glusterd_t)
+	rpc_domtrans_nfsd(glusterd_t)
+	rpc_domtrans_rpcd(glusterd_t)
+	rpc_kill_rpcd(glusterd_t)
+	rpc_manage_nfs_state_data(glusterd_t)
+	rpc_manage_nfs_state_data_dir(glusterd_t)
+	rpc_systemctl_nfsd(glusterd_t)
+	rpc_systemctl_rpcd(glusterd_t)
+	rpcbind_stream_connect(glusterd_t)
 ')
 
 optional_policy(`
@@ -313,40 +329,19 @@ optional_policy(`
 	rsync_rw_unix_stream_sockets(glusterd_t)
 ')
 
-optional_policy(`
-    rpc_systemctl_nfsd(glusterd_t)
-    rpc_systemctl_rpcd(glusterd_t)
-    rpc_domtrans_nfsd(glusterd_t)
-    rpc_dbus_chat_nfsd(glusterd_t)
-    rpc_domtrans_rpcd(glusterd_t)
-    rpc_manage_nfs_state_data(glusterd_t)
-	rpc_manage_nfs_state_data_dir(glusterd_t)
-	rpcbind_stream_connect(glusterd_t)
-')
-
-optional_policy(`
-    rhcs_dbus_chat_cluster(glusterd_t)
-    rhcs_domtrans_cluster(glusterd_t)
-    rhcs_systemctl_cluster(glusterd_t)
-    rhcs_stream_connect_cluster(glusterd_t)
-')
-
-optional_policy(`
-	ssh_exec(glusterd_t)
-')
-
-
 ########################################
 #
 # Local policy for ssh_keygen
 #
 
-gen_require(`
-    type ssh_keygen_t;
-')
+optional_policy(`
+	gen_require(`
+		type ssh_keygen_t;
+	')
 
-manage_dirs_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)
-manage_files_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)
+	manage_dirs_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)
+	manage_files_pattern(ssh_keygen_t, glusterd_var_lib_t, glusterd_var_lib_t)
+')
 
 ########################################
 #

--- a/glusterfs-selinux.spec
+++ b/glusterfs-selinux.spec
@@ -33,6 +33,10 @@ make %{?_smp_mflags}
 
 %install
 %make_install
+%if 0%{?fedora} >= 33 || 0%{?rhel} >= 8
+	install -D -p -m 644 ${TARGET}.if ${DESTDIR}${SHAREDIR}/selinux/devel/include/contrib/ipp-${TARGET}.if
+%endif
+
 
 
 %pre
@@ -54,6 +58,9 @@ fi
 
 
 %files
+%if 0%{?fedora} >= 33 || 0%{?rhel} >= 8
+	%{_datadir}/selinux/devel/include/%{moduletype}/ipp-%{modulename}.if
+%endif
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
 %ghost %attr(700, root, root) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
 %license COPYING


### PR DESCRIPTION
Fixed policy according to the Reference Policy Style Guideline
https://github.com/SELinuxProject/refpolicy/wiki/StyleGuide

Alphabetically sorted rules and permissios.

Macros: fstools_domtrans, mount_domtrans,
systemd_config_systemd_services, systemd_signal_passwd_agent,
moved to optional policy blocks.

Removed duplicated macros.

Removed whitespaces.

Added '\' before .py in fc file.