### PR TITLE
glusterfs-selinux package should own the files created by it

### DIFF
--- a/glusterfs-selinux.spec
+++ b/glusterfs-selinux.spec
@@ -56,6 +56,9 @@ fi
 %files
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*
 %ghost %attr(700, root, root) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
+%ghost %attr(600, root, root) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}/cil
+%ghost %attr(600, root, root) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}/hll
+%ghost %attr(600, root, root) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}/lang_ext
 %license COPYING
 
 


### PR DESCRIPTION
The package currently own only the directory, but not the files
created by the package. This makes these files look as being
belong to no package, which is incorrect.

RHBZ: https://bugzilla.redhat.com/1955415

Signed-off-by: Lev Veyde <lveyde@redhat.com>