### PR TITLE
Add glusterd_stream_connect interface

### DIFF
--- a/glusterd.if
+++ b/glusterd.if
@@ -40,6 +40,24 @@ interface(`glusterd_initrc_domtrans',`
 	init_labeled_script_domtrans($1, glusterd_initrc_exec_t)
 ')
 
+#######################################
+## <summary>
+##  Connect to glusterd over a unix stream socket.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`glusterd_stream_connect',`
+	gen_require(`
+		type glusterd_t;
+	')
+
+	allow $1 glusterd_t:unix_stream_socket connectto;
+')
+
 ########################################
 ## <summary>
 ##	Read glusterd's log files.

--- a/glusterd.if
+++ b/glusterd.if
@@ -42,12 +42,12 @@ interface(`glusterd_initrc_domtrans',`
 
 #######################################
 ## <summary>
-##  Connect to glusterd over a unix stream socket.
+##	Connect to glusterd over a unix stream socket.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_stream_connect',`
@@ -99,19 +99,19 @@ interface(`glusterd_append_log',`
 
 #######################################
 ## <summary>
-##  Transition content labels to glusterd named content
+##	Transition content labels to glusterd named content
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##      Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_filetrans_named_pid',`
-    gen_require(`
-        type glusterd_var_run_t;
-    ')
-    files_pid_filetrans($1, glusterd_var_run_t , sock_file, "glusterd.socket")
+	gen_require(`
+		type glusterd_var_run_t;
+	')
+	files_pid_filetrans($1, glusterd_var_run_t , sock_file, "glusterd.socket")
 ')
 
 ########################################
@@ -157,98 +157,98 @@ interface(`glusterd_manage_log',`
 
 ######################################
 ## <summary>
-##  Allow the specified domain to execute gluster's lib files.
+##	Allow the specified domain to execute gluster's lib files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`gluster_execute_lib',`
-    gen_require(`
-        type glusterd_var_lib_t;
-    ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    files_list_var_lib($1)
-    allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    can_exec($1, glusterd_var_lib_t)
+	files_list_var_lib($1)
+	allow $1 glusterd_var_lib_t:dir search_dir_perms;
+	can_exec($1, glusterd_var_lib_t)
 ')
 
 ######################################
 ## <summary>
-##  Read glusterd's config files.
+##	Read glusterd's config files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_read_conf',`
-       gen_require(`
-               type glusterd_conf_t;
-       ')
+	gen_require(`
+		type glusterd_conf_t;
+	')
 
-    files_search_etc($1)
-    read_files_pattern($1, glusterd_conf_t, glusterd_conf_t)
+	files_search_etc($1)
+	read_files_pattern($1, glusterd_conf_t, glusterd_conf_t)
 ')
 
 ######################################
 ## <summary>
-##  Dontaudit Read  /var/lib/glusterd files.
+##	Dontaudit Read /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_dontaudit_read_lib_dirs',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    dontaudit $1 glusterd_var_lib_t:dir list_dir_perms;
+	dontaudit $1 glusterd_var_lib_t:dir list_dir_perms;
 ')
 
 ######################################
 ## <summary>
-##  Read and write /var/lib/glusterd files.
+##	Read and write /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##  <summary>
-##  Domain allowed access.
-##  </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_rw_lib',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
-    rw_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	files_search_var_lib($1)
+	rw_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
 ## <summary>
-## Read /var/lib/glusterd files.
+##	Read /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_read_lib_files',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
+	files_search_var_lib($1)
 	allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    read_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	read_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
@@ -256,19 +256,19 @@ interface(`glusterd_read_lib_files',`
 ## Read and write /var/lib/glusterd files.
 ## </summary>
 ## <param name="domain">
-##     <summary>
-##     Domain allowed access.
-##     </summary>
+##	<summary>
+##	Domain allowed access.
+##	</summary>
 ## </param>
 #
 interface(`glusterd_manage_lib_files',`
-       gen_require(`
-               type glusterd_var_lib_t;
-       ')
+	gen_require(`
+		type glusterd_var_lib_t;
+	')
 
-    files_search_var_lib($1)
+	files_search_var_lib($1)
 	allow $1 glusterd_var_lib_t:dir search_dir_perms;
-    manage_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
+	manage_files_pattern($1, glusterd_var_lib_t, glusterd_var_lib_t)
 ')
 
 ######################################
@@ -300,9 +300,9 @@ interface(`glusterd_admin',`
 	allow $1 glusterd_t:process { signal_perms };
 	ps_process_pattern($1, glusterd_t)
 
-    tunable_policy(`deny_ptrace',`',`
-        allow $1 glusterd_t:process ptrace;
-    ')
+	tunable_policy(`deny_ptrace',`',`
+		allow $1 glusterd_t:process ptrace;
+	')
 
 	glusterd_initrc_domtrans($1)
 	domain_system_change_exemption($1)
@@ -339,8 +339,8 @@ interface(`glusterd_admin',`
 #
 ifndef(`rsync_rw_unix_stream_sockets',`
 	interface(`rsync_rw_unix_stream_sockets',`
-        	gen_require(`
-	    		type rsync_t;
+		gen_require(`
+			type rsync_t;
 		')
 
 		allow $1 rsync_t:unix_stream_socket rw_socket_perms;


### PR DESCRIPTION
The interface was introduced in:
https://github.com/fedora-selinux/selinux-policy/commit/ba981cd41608b254b95d6489af12cc2d25c00f5b

This is a final sync-up with selinux-pilicy repository. Starting with
Fedora 35, glusterd policy module will no longer be shipped in the
distribution policy.

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>