### PR TITLE
Prepare for anon inode controls enablement

### DIFF
--- a/glusterd.te
+++ b/glusterd.te
@@ -129,6 +129,9 @@ kernel_read_system_state(glusterd_t)
 kernel_read_network_state(glusterd_t)
 kernel_read_net_sysctls(glusterd_t)
 kernel_request_load_module(glusterd_t)
+ifdef(`kernel_io_uring_use',`
+	kernel_io_uring_use(glusterd_t)
+')
 
 corecmd_exec_bin(glusterd_t)
 corecmd_exec_shell(glusterd_t)


### PR DESCRIPTION
We plan to start labeling anon inodes (userfaultfd and io_uring file
descriptors) properly in selinux-policy, which means that domains using
these will need new rules.

See: https://github.com/fedora-selinux/selinux-policy/pull/1351

Since glusterd uses io_uring, this patch adds the necessary interface
call to its policy to avoid a regression. As the new interface call is
put under a conditional, the policy package will be buildable against
selinux-policy with or without the above PR merged, but it will need to
be rebuilt against the updated selinux-policy to actually pick up the
new rules.